### PR TITLE
Fix for Nodejs-0.6.12

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -199,7 +199,8 @@ req.end(JSON.stringify(query));
 var mappingReady = false;
 var hitQueue = [];
 
-var req = http.get('http://' + opts.sourceHost + ':' + opts.sourcePort + source + '_mapping', function(res) {
+var options = { host: opts.sourceHost, port: opts.sourcePort, path: source + '_mapping' };
+var req = http.get(options, function(res) {
 	var data = '';
 	res.on('data', function(chunk) {
 		data += chunk;


### PR DESCRIPTION
I had to change this http.get call in order for it not to throw

```
Caught exception in Main process: Error: connect ECONNREFUSED
Error: connect ECONNREFUSED
    at errnoException (net.js:646:11)
    at Object.afterConnect [as oncomplete] (net.js:637:18)

```

Nodejs version is 0.6.12 installed from Ubuntu 12.04 package repository.

```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=12.04
DISTRIB_CODENAME=precise
DISTRIB_DESCRIPTION="Ubuntu 12.04.1 LTS"
```

```
$ node --version
v0.6.12
```
