### PR TITLE
Fixes issue where process was ended too early

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -140,7 +140,6 @@ function storeHits(hits) {
     }
 	var data = '';
 	hits.forEach(function(hit) {
-		processedHits++;
         if (!hit) {
             return;
         }
@@ -159,12 +158,12 @@ function storeHits(hits) {
             });
 		}
 		data += JSON.stringify(metaData) + '\n' + JSON.stringify(hit._source) + '\n';
-		if (processedHits % 100 === 0) {
-			console.log('Processed %s of %s entries (%s%%)', processedHits, totalHits, Math.round(processedHits / totalHits * 100));
-		}
 	});
     if (data.length) {
         targetDriver.storeHits(opts, data, function() {
+            processedHits += hits.length;
+            console.log('Processed %s of %s entries (%s%%)', processedHits, totalHits, Math.round(processedHits / totalHits * 100));
+
             if (processedHits == totalHits) {
                 process.exit(0);
             }


### PR DESCRIPTION
`processedHits` is counted up in the global scope before they are actually being processed. After they are processed `processedHits` is used to check if all hits have been stored. 

The issue here is, that `processedHits` can already be equal to `totalHits` even though the last request hasn't finished successfully. And since that causes the process to exit, the running request is cancelled and the last hits are lost.
