### PR TITLE
Bugfix unreleased sockets

### DIFF
--- a/drivers/es.js
+++ b/drivers/es.js
@@ -176,7 +176,11 @@ exports.storeHits = function(opts, data, callback) {
 		port : opts.targetPort,
 		path : '_bulk',
 		method : 'POST'
-	}, callback);
+	}, function(res) {
+		//Data must be fetched, otherwise socket won't be set to free
+		res.on('data', function (chunk) {});
+		callback(res);
+	});
     putReq.on('error', console.log);
 	putReq.end(data);
 };


### PR DESCRIPTION
With Node 0.10.11 only the first five requests to target ElasticSearch were executed. All other requests were queued inside the http agent and waited for a new free socket. 
Adding a dummy callback for the response data solves this problem - but maybe it's more a bug of Node.
