### PR TITLE
add a sourceSize option to improve speed on large indices

### DIFF
--- a/drivers/es.js
+++ b/drivers/es.js
@@ -96,6 +96,7 @@ exports.getData = function(opts, callback) {
         fields : [
             '_source', '_timestamp', '_version', '_routing', '_percolate', '_parent', '_ttl'
         ],
+        size : opts.sourceSize,
         query : opts.sourceQuery
     };
     if (opts.sourceIndex) {
@@ -103,6 +104,7 @@ exports.getData = function(opts, callback) {
             fields : [
                 '_source', '_timestamp', '_version', '_routing', '_percolate', '_parent', '_ttl'
             ],
+            size : opts.sourceSize,
             query : {
                 indices : {
                     indices : [
@@ -119,6 +121,7 @@ exports.getData = function(opts, callback) {
             fields : [
                 '_source', '_timestamp', '_version', '_routing', '_percolate', '_parent', '_ttl'
             ],
+            size : opts.sourceSize,
             query : {
                 indices : {
                     indices : [

--- a/options.js
+++ b/options.js
@@ -51,6 +51,12 @@ var nomnom = require('nomnom').script('exporter').options({
             match_all:{}
         }
     },
+    sourceSize : {
+        abbr : 'z',
+        metavar: '<size>',
+        help: 'The maximum number of results to be returned per query.',
+        'default' : 10
+    },
     sourceFile : {
         abbr : 'f',
         metavar : '<filebase>',


### PR DESCRIPTION
Hi, thanks for the great project.

I've used the exporter with indices containing hundreds of millions of documents and needed an easy way to increase the query size from elasticsearch's default of 10, so I thought sourceSize makes sense.

I've tested that this works as expected, let me know if there are any issues.
