### PR TITLE
Adding colors as an explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 	"keywords": ["export", "import", "elastichsearch", "data pump"],
 	"dependencies": {
 		"nomnom": "1.6",
-		"through": "2.3"
+		"through": "2.3",
+		"colors": "~0.6.2"
 	},
 	"engine": {
 		"node": ">=0.10"


### PR DESCRIPTION
When including `elasticsearchExporter` in my project's `package.json` I was getting the following error:
    module.js:340
        throw err;
              ^
    Error: Cannot find module 'colors'
        at Function.Module._resolveFilename (module.js:338:15)
        at Function.Module._load (module.js:280:25)
        at Module.require (module.js:362:17)
        at require (module.js:378:17)
        at Object.<anonymous> (/Users/cbaclig/Projects/Elasticsearch-Exporter/options.js:3:1)
        at Module._compile (module.js:449:26)
        at Object.Module._extensions..js (module.js:467:10)
        at Module.load (module.js:356:32)
        at Function.Module._load (module.js:312:12)
        at Module.runMain (module.js:492:10)

Adding `colors` to this `package.json` does the trick
