### PR TITLE
Fix getLineCount for correct progress reporting.

### DIFF
--- a/drivers/file.js
+++ b/drivers/file.js
@@ -88,10 +88,17 @@ function getLineCount(opts, callback) {
     var file = opts.sourceFile + '.data';
     var stream = opts.sourceCompression ? fs.createReadStream(file).pipe(zlib.createGunzip()) : fs.createReadStream(file);
 
-    stream.on('readable', function() {
+    stream.on('data', function(streamRead) {
         try {
-            count += (''+ stream.read()).match(/\n/g).length;
-        } catch (e) {}
+            var linesInChunk = (''+streamRead).match(/\n/g);
+            var lineCountInChunk = 0;
+            if (linesInChunk !== null) {
+                lineCountInChunk = linesInChunk.length;
+            } 
+            count += lineCountInChunk; 
+        } catch (e) { 
+            console.log(e);
+        }
     });
     stream.on('end', function() {
         exports.lineCount = Math.ceil(count/2);


### PR DESCRIPTION
I was importing from a file into my local elasticsearch cluster, I noticed Percentage progress was incorrect, leading to an "Infinity" for the percentage completed.

I traced this back to the getLineCount function, where the 'readable' event wasn't firing. Refactored the code
to use 'data' callback instead, and improved error handling.
