### PR TITLE
Use auth for search requests

### DIFF
--- a/drivers/es.js
+++ b/drivers/es.js
@@ -448,6 +448,7 @@ exports.getData = function(opts, callback, retries) {
         var scrollReq = http.request({
             host : opts.sourceHost,
             port : opts.sourcePort,
+            auth: opts.sourceAuth,
             path : '/_search/scroll?scroll=5m',
             method : 'POST',
             headers: {
@@ -466,6 +467,7 @@ exports.getData = function(opts, callback, retries) {
         var firstReq = http.request({
             host : opts.sourceHost,
             port : opts.sourcePort,
+            auth: opts.sourceAuth,
             path : '/_search?search_type=scan&scroll=5m',
             method : 'POST',
             headers: {


### PR DESCRIPTION
It seems like you are missing **auth: opts.sourceAuth** or **auth: opts.targetAuth** each time _http.request_ is performed. So it's not possible to use the exporter with basic auth without fixing it manualy.

```
http.request({
            host : opts.sourceHost,
            port : opts.sourcePort,
            auth: opts.sourceAuth,
```
