### PR TITLE
Throttling in ES when the cluster nodes have High CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ individual steps.
 It might help if you change the size of each scan request that fetches data. The current default of the option `--source.size` is set to 10. Increasing or decreasing
 this value might have great performance impact on the actual export.
 
+### Elastic search throttling
+If the cluster you are working with is used in production it will be good to set a limit of the CPU usage on any of the nodes over which no data will be get/put from/to the elastic search cluster. To do so you can set throttle CPU limit to both source(`-sTC 80`) and target(`-tTC 80`) to a given percent. In addition to this you can set the timeout before the next try(`-sTT 2000` or `-tTT 2000`), the default value of that options is set to 1000.
+
 ### Disable replication
 
 The default setting for any index to create 1 replica for each shard. While this is generally speaking a good thing, it can be really bad while importing a new index.

--- a/exporter.js
+++ b/exporter.js
@@ -270,6 +270,7 @@ exports.transferData = function (callback) {
     pump.onWorkDone(function(processedDocs) {
         processed += processedDocs;
         exports.env.statistics.source.docs.processed = processed;
+        log.status('                                                                    ');
         log.status('Processed %s of %s entries (%s%%)', processed, total, Math.round(processed / total * 100));
     });
     pump.onEnd(function() {

--- a/worker.js
+++ b/worker.js
@@ -201,10 +201,12 @@ exports.storeData = function (hits) {
             callback();
         });
     }, function (err) {
-        if (exports.env.options.errors.ignore) {
-            exports.send.done(hits.length);
-        } else {
-            exports.send.error(err);
+        if (err) {
+            if (exports.env.options.errors.ignore) {
+                exports.send.done(hits.length);
+            } else {
+                exports.send.error(err);
+            }
         }
     });
 };


### PR DESCRIPTION
Thanks for accepting my previous pull request, this is great!

Today I've spent some time to add some type of throttling for the elastic search requests when the CPU of any of the cluster nodes have reached a certain limit, so would you please take a look at my suggestion and accept the pull request if you like this feature. The idea is to be able to run the tool on a production cluster and not affect the performance by overloading the cluster itself. 
Thanks again for Your time and for the great tool!