### PR TITLE
Use graceful-fs in the "file" driver

### DIFF
--- a/drivers/file.driver.js
+++ b/drivers/file.driver.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 var async = require('async');

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "colors": ">=0.5.x",
     "json-bigint": "^0.1.4",
     "mongodb": "^2.0.39",
-    "mysql": "2.5.x"
+    "mysql": "2.5.x",
+    "graceful-fs": ">=4.1.2"
   },
   "devDependencies": {
     "chai": "1.10.x",


### PR DESCRIPTION
When exporting a cluster with many indices it is highly likely to
hit the EMFILE errors with the fs plugin. graceful-fs tries to avoid
these errors "gracefully".

--
Note: from what I understand this should be enough, and it seems to fix the `EMFILE` error I saw, but I'm still verifying that the export actually worked completely (it's a ES 1.4.x cluster with a few hundred indices of very varying sizes)