### PR TITLE
typo in env.options.target

### DIFF
--- a/drivers/file.driver.js
+++ b/drivers/file.driver.js
@@ -364,7 +364,7 @@ exports.end = function (env) {
 
     function typeTask(index, type) {
         return function(callback) {
-            exports.archive.read(env.option.target.file, index, type, 'count', function(err, data) {
+            exports.archive.read(env.options.target.file, index, type, 'count', function(err, data) {
                 if (!err && !isNaN(data)) {
                     exports.counts[index][type] += parseInt(data);
                 }


### PR DESCRIPTION
This is a fix for a very small but show-stopping bug: The typo "env.option.target"  instead of "env.options.target" made the file plugin unusable.