### PR TITLE
Transformation during indexing

### DIFF
--- a/cluster.js
+++ b/cluster.js
@@ -154,6 +154,8 @@ var NoCluster = function(env) {
     this.worker.env = env;
     this.worker.id = 0;
 
+    this.worker.initialize_transform();
+
     var source = drivers.get(env.options.drivers.source).driver;
     if (source.prepareTransfer) {
         source.prepareTransfer(env, true);

--- a/example-transform-function.js
+++ b/example-transform-function.js
@@ -1,0 +1,3 @@
+function transform(obj) {
+	return obj;
+}

--- a/fn-encapsulate.js
+++ b/fn-encapsulate.js
@@ -1,0 +1,42 @@
+var path = require('path');
+var crypto = require('crypto');
+var fs = require('fs');
+
+var Module = module.constructor;
+
+module.exports = function(functionFilename, expectedFunctionName) {
+
+	function generateFakeFilename() {
+		var absoluteFilename = path.resolve(functionFilename);
+		var hash = crypto.createHmac('sha256', 'encap').update(absoluteFilename).digest('hex');
+		var shortHash = hash.substr(hash.length - 16, hash.length - 1);
+		return 'fn_encapsulator_' + shortHash;
+	}
+
+	function createFakeModule(fakeFilename, functionName, functionCode) {
+
+		var moduleCode = "module.exports." + functionName + " = (" + functionCode + ");\n";
+
+		var m = new Module(fakeFilename, module.parent);
+		m.paths = Module._nodeModulePaths(path.dirname('.'));
+		m._compile(moduleCode, fakeFilename);
+		return m;
+	}
+
+	function validateModule(m) {
+		var exportedFunctions = Object.keys(m.exports);
+
+		if (!exportedFunctions || exportedFunctions.length !== 1) {
+			throw new Error("Expected exactly one function in function file.");
+		}
+	}
+
+	var fakeFilename = generateFakeFilename();
+	var functionCode = fs.readFileSync(functionFilename, 'utf8');
+
+	var m = createFakeModule(fakeFilename, expectedFunctionName, functionCode);
+
+	validateModule(m);
+
+	return m.exports;
+};

--- a/options.js
+++ b/options.js
@@ -63,6 +63,12 @@ var OPTIONS = {
             help: 'Flag to enable copying data. If set to false all data copy operations are skipped.',
             preset: true
         }
+    }, xform: {
+        file: {
+            abbr: 'xf',
+            help: 'Filename for transform function which gets an object and returns the transformed object'
+        }
+        // TODO Control smarter error handling of transforms
     }, "memory.limit": {
         abbr: 'ml',
         help: 'Set how much of the available memory the process should use for caching data to be written to the target driver. Should be a float value between 0 and 1 (make sure to pass --nouse-idle-notification --expose-gc as node OPTIONS to make this work)',

--- a/test/worker.mock.js
+++ b/test/worker.mock.js
@@ -19,6 +19,10 @@ process.on('message', function (m) {
     }
 });
 
+exports.initialize_transform = function() {
+    exports.transform_function = null;
+};
+
 exports.send = {
     error: function (id, exception) {
         process.send({


### PR DESCRIPTION
Hi, great tool!

I've taken the liberty of adding the capability to provide a transformation function for changing the data during reindexing on-the-fly. I believe it addresses issue #54 and #83 in a simple to use way and provides a lot of power to the users (I added it because I needed to change some values during migrating an index due to app changes).

WDYT? Your comments and remarks are most welcome of course.

If you believe it's worthy of adding to the tool, then there can be additional interesting stuff to add afterwards:
- Pass metadata to function (src/target info)
- Allow batch conversion as well
- Allow user to provide a full-blown module as well (so it can include external dependencies and maintain some simple state)
- Allow user to transform one record to either 0 (removal) or more than one (split) records
- More flexible error handling during transformation (ignore up to X, X%, etc.)

Harel